### PR TITLE
Fix error in getitem node widget

### DIFF
--- a/src/openalea/python/list_selector.py
+++ b/src/openalea/python/list_selector.py
@@ -18,7 +18,7 @@ from qtpy import QtGui, QtCore, QtWidgets
 from openalea.core.observer import lock_notify
 from openalea.visualea.node_widget import NodeWidget
 
-class ListSelectorWidget(QtWidgets.QListWidget, NodeWidget):
+class ListSelectorWidget(NodeWidget, QtWidgets.QListWidget):
     """ This Widget allows to select an element in a list
     or in a dictionnary """
 


### PR DESCRIPTION
Change order in inheritance classes 

```python
class ListSelectorWidget(NodeWidget, QtWidgets.QListWidget):
    pass
```

rather than 
```python
class ListSelectorWidget(QtWidgets.QListWidget, NodeWidget):
    pass
```
